### PR TITLE
Fix maim commands

### DIFF
--- a/dwm/config.def.h
+++ b/dwm/config.def.h
@@ -67,9 +67,9 @@ static const char *termcmd[]  = { "alacritty", NULL };
 static const char *web[]  = { "firefox", NULL };
 static const char *files[]  = { "pcmanfm", NULL };
 static const char *editor[]  = { "codium", NULL };
-static const char *print_screen_cmd[] = { "maim", "~/Pictures/Screenshots/$(date +%s).png", NULL };
-static const char *print_region_cmd[] = { "maim", "-s", "~/Pictures/Screenshots/$(date +%s).png", NULL };
-static const char *print_window_cmd[] = { "maim", "-i", "$(xdotool getactivewindow)", "~/Pictures/Screenshots/$(date +%s).png", NULL };
+static const char *print_screen_cmd[] = { "/bin/sh", "-c", "maim ~/Pictures/Screenshots/$(date +%s).png", NULL };
+static const char *print_region_cmd[] = { "/bin/sh", "-c", "maim -s ~/Pictures/Screenshots/$(date +%s).png", NULL };
+static const char *print_window_cmd[] = { "/bin/sh", "-c", "maim -i $(xdotool getactivewindow) ~/Pictures/Screenshots/$(date +%s).png", NULL };
 /* test */
 static Key keys[] = {
 	/* modifier                     key        function        argument */


### PR DESCRIPTION
Commands using Substitution and non absolute paths need to be executed in shell.